### PR TITLE
Feat #15 : 리프레시 토큰 구현

### DIFF
--- a/src/main/java/com/example/skeleton/domain/client/controller/ClientController.java
+++ b/src/main/java/com/example/skeleton/domain/client/controller/ClientController.java
@@ -27,12 +27,20 @@ public class ClientController {
     private final ClientService clientService;
     private final ClientSignInService clientSignInService;
 
+    /**
+     * 회원 가입
+     * @param resqDto
+     */
     @PostMapping("/sign-up")
     public ResponseEntity<ClientResponseDto> signUp(@RequestBody ClientRequestDto resqDto) {
         ClientResponseDto respDto = clientService.signUp(resqDto);
         return ResponseEntity.status(respDto.getStatus()).body(respDto);
     }
 
+    /**
+     * 로그인(동시에 액세스 토큰 발급)
+     * @param clientSignInRequestDto
+     */
     @PostMapping("/sign-in")
     public ResponseEntity<AccessTokenCreationResponseDto> signIn(
             @RequestBody
@@ -41,12 +49,20 @@ public class ClientController {
         return ResponseEntity.ok(clientSignInService.signIn(clientSignInRequestDto));
     }
 
+    /**
+     * 회원정보 수정
+     * @param resqDto
+     */
     @PutMapping
     public ResponseEntity<ClientResponseDto> setClientInfo(@RequestBody ClientRequestDto resqDto) {
         ClientResponseDto respDto = clientService.setClientInfo(resqDto);
         return ResponseEntity.status(respDto.getStatus()).body(respDto);
     }
 
+    /**
+     * 회원정보 조회
+     * @param clientId
+     */
     @GetMapping("/{clientId}")
     public ResponseEntity<ClientResponseDto> getClientInfo(@PathVariable String clientId) {
         ClientResponseDto respDto = clientService.getClientInfo(clientId);

--- a/src/main/java/com/example/skeleton/domain/client/service/ClientServiceImpl.java
+++ b/src/main/java/com/example/skeleton/domain/client/service/ClientServiceImpl.java
@@ -19,11 +19,10 @@ import lombok.RequiredArgsConstructor;
 public class ClientServiceImpl implements ClientService {
 
         private final ClientRepository clientRepo;
-//        private final PasswordEncoder passwordEncoder;
+        private final PasswordEncoder passwordEncoder;
 
         @Override
         public ClientResponseDto signUp(ClientRequestDto dto) {
-                PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
                 // 아이디 중복 체크
                 if (clientRepo.existsByClientId(dto.getClientId())) {

--- a/src/main/java/com/example/skeleton/domain/client/service/ClientSignInService.java
+++ b/src/main/java/com/example/skeleton/domain/client/service/ClientSignInService.java
@@ -18,6 +18,10 @@ public class ClientSignInService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
+    /**
+     * 로그인 & 동시에 액세스 토큰 발급
+     * @param clientSignInRequestDto
+     */
     public AccessTokenCreationResponseDto signIn(ClientSignInRequestDto clientSignInRequestDto) {
         Client client = clientRepository.findByClientId(clientSignInRequestDto.getClientId())
                 .orElseThrow(() -> new EntityNotFoundException("클라이언트를 찾을 수 없습니다."));

--- a/src/main/java/com/example/skeleton/domain/jwt/controller/RefreshTokenController.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/controller/RefreshTokenController.java
@@ -1,0 +1,32 @@
+package com.example.skeleton.domain.jwt.controller;
+
+import com.example.skeleton.domain.jwt.dto.RenewAccessTokenRequestDto;
+import com.example.skeleton.domain.jwt.dto.RenewAccessTokenResponseDto;
+import com.example.skeleton.domain.jwt.service.RefreshTokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/token")
+@RequiredArgsConstructor
+public class RefreshTokenController {
+
+    private final RefreshTokenService refreshTokenService;
+
+    /**
+     * 리프레시 토큰을 통해 액세스 토큰 만료기한 갱신
+     * @param requestDto
+     */
+    @PostMapping
+    public ResponseEntity<RenewAccessTokenResponseDto> renewAccessTokenByRefreshToken(
+            @RequestBody RenewAccessTokenRequestDto requestDto
+    ) {
+        String renewedAccessToken = refreshTokenService.renewAccessTokenByRefreshToken(requestDto.getRefreshToken());
+        return ResponseEntity.ok(RenewAccessTokenResponseDto.of(renewedAccessToken));
+    }
+
+}

--- a/src/main/java/com/example/skeleton/domain/jwt/dto/RenewAccessTokenRequestDto.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/dto/RenewAccessTokenRequestDto.java
@@ -1,0 +1,10 @@
+package com.example.skeleton.domain.jwt.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RenewAccessTokenRequestDto {
+    private String refreshToken;
+}

--- a/src/main/java/com/example/skeleton/domain/jwt/dto/RenewAccessTokenResponseDto.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/dto/RenewAccessTokenResponseDto.java
@@ -1,0 +1,17 @@
+package com.example.skeleton.domain.jwt.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class RenewAccessTokenResponseDto {
+    private String accessToken;
+
+    public static RenewAccessTokenResponseDto of(String renewedAccessToken) {
+        return new RenewAccessTokenResponseDto(renewedAccessToken);
+    }
+}

--- a/src/main/java/com/example/skeleton/domain/jwt/entity/RefreshToken.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/entity/RefreshToken.java
@@ -1,0 +1,26 @@
+package com.example.skeleton.domain.jwt.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String refreshToken;
+
+    private String clientId;
+
+    public RefreshToken(String refreshToken, String clientId) {
+        this.refreshToken = refreshToken;
+        this.clientId = clientId;
+    }
+}

--- a/src/main/java/com/example/skeleton/domain/jwt/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/repository/RefreshTokenRepository.java
@@ -1,0 +1,7 @@
+package com.example.skeleton.domain.jwt.repository;
+
+import com.example.skeleton.domain.jwt.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+}

--- a/src/main/java/com/example/skeleton/domain/jwt/service/RefreshTokenService.java
+++ b/src/main/java/com/example/skeleton/domain/jwt/service/RefreshTokenService.java
@@ -1,0 +1,46 @@
+package com.example.skeleton.domain.jwt.service;
+
+import com.example.skeleton.domain.client.entity.Client;
+import com.example.skeleton.domain.client.repository.ClientRepository;
+import com.example.skeleton.domain.jwt.entity.RefreshToken;
+import com.example.skeleton.domain.jwt.repository.RefreshTokenRepository;
+import com.example.skeleton.global.config.jwt.JwtTokenProvider;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final ClientRepository clientRepository;
+
+    /**
+     * 리프레시 토큰을 통해 액세스 토큰 만료기한 갱신
+     * @param refreshToken
+     */
+    public String renewAccessTokenByRefreshToken(String refreshToken) {
+
+        // 1. 현재 사용자의 clientId 찾기
+        String clientId = jwtTokenProvider.getClientIdFromToken();
+
+        // 2. 주어진 refreshToken 유효성 검사
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("유효하지 않은 refreshToken입니다.");
+        }
+
+        // 3. 리프레시 토큰 생성 및 저장
+        RefreshToken refreshTokenForRenewal = new RefreshToken(refreshToken, clientId);
+        refreshTokenRepository.save(refreshTokenForRenewal);
+
+        // 4. 새로운 액세스 토큰 생성
+        Client client = clientRepository.findByClientId(clientId)
+                .orElseThrow(() -> new EntityNotFoundException("Client를 찾을 수 없습니다: " + clientId));
+        String newAccessToken = jwtTokenProvider.issueToken(client, "access");
+
+        return newAccessToken;
+    }
+}
+

--- a/src/main/java/com/example/skeleton/global/config/jwt/JwtTokenAuthenticationFilter.java
+++ b/src/main/java/com/example/skeleton/global/config/jwt/JwtTokenAuthenticationFilter.java
@@ -10,8 +10,6 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 @RequiredArgsConstructor
 public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
@@ -29,17 +27,6 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        // 토큰이 필요하지 않은 API URI의 배열 구성
-        List<String> uriListWithoutToken = Arrays.asList(
-                "/swagger-ui/**", "/h2-console/**", "/api/clients/sign-up", "/api/clients/sign-in"
-        );
-
-        // 토큰이 필요하지 않은 URI들은 JWT 관련 로직을 거치지 않고 다음 필터로 이동
-        if (uriListWithoutToken.contains(request.getRequestURI())) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
         // 요청 헤터의 AUTHORIZATION 키 값 조회
         String authorizationHeader = request.getHeader(HEADER_AUTHOR);
 
@@ -47,7 +34,7 @@ public class JwtTokenAuthenticationFilter extends OncePerRequestFilter {
             // 가져온 값에서 TOKEN_PREFIX "Bearer "를 제거한 실제 토큰값
             String token = getAccessToken(authorizationHeader);
 
-            if (jwtTokenProvider.validToken(token)) {
+            if (jwtTokenProvider.validateToken(token)) {
                 Authentication authentication = jwtTokenProvider.getAuthentication(token);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/src/main/java/com/example/skeleton/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/skeleton/global/config/security/SecurityConfig.java
@@ -6,12 +6,15 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+
+import static org.springframework.boot.autoconfigure.security.servlet.PathRequest.toH2Console;
 
 @Configuration
 @RequiredArgsConstructor
@@ -22,6 +25,12 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public WebSecurityCustomizer configure() {
+        return (web) -> web.ignoring()
+                .requestMatchers(toH2Console());
     }
 
     @Bean
@@ -36,9 +45,7 @@ public class SecurityConfig {
                 .csrf().disable()
                 .cors().disable()
                 .headers(headers -> headers.frameOptions().sameOrigin())
-                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                .and()
-                .addFilterBefore(jwtTokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);
 
         http
                 .authorizeHttpRequests(auth -> auth
@@ -51,7 +58,8 @@ public class SecurityConfig {
                         ).permitAll()
                         // 권한 설정이 필요한 페이지 확인 후 변경할 것
                         .anyRequest().permitAll()
-                );
+                )
+                .addFilterBefore(jwtTokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,6 @@
 spring:
   jpa:
-    properties:
-      hibernate:
-        show_sql: true
+#    show_sql: true
   h2:
     console:
       enabled: true

--- a/src/test/java/com/example/skeleton/domain/jwt/controller/RefreshTokenControllerTest.java
+++ b/src/test/java/com/example/skeleton/domain/jwt/controller/RefreshTokenControllerTest.java
@@ -1,0 +1,85 @@
+package com.example.skeleton.domain.jwt.controller;
+
+import com.example.skeleton.IntegrationTest;
+import com.example.skeleton.domain.client.dto.ClientSignInRequestDto;
+import com.example.skeleton.domain.client.entity.Client;
+import com.example.skeleton.domain.client.repository.ClientRepository;
+import com.example.skeleton.global.config.jwt.JwtTokenProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class RefreshTokenControllerTest extends IntegrationTest {
+
+    @Autowired
+    PasswordEncoder passwordEncoder;
+
+    @Autowired
+    ClientRepository clientRepository;
+
+    @Autowired
+    JwtTokenProvider jwtTokenProvider;
+
+    @Test
+    void renewAccessTokenByRefreshToken_succeed() throws Exception {
+        // given
+        // 1. 회원가입
+        Client client = Client.builder()
+                .clientId("refreshedClient")
+                .password(passwordEncoder.encode("vcxz4567"))
+                .build();
+
+        clientRepository.save(client);
+
+        // 2. 로그인 시뮬레이션
+        String clientId = client.getClientId();
+        String password = "vcxz4567";
+
+        ClientSignInRequestDto clientSignInRequestDto = ClientSignInRequestDto.of(clientId, password);
+
+        MvcResult resultOfSignIn = mvc.perform(
+                post("/api/clients/sign-in")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clientSignInRequestDto))
+        )
+                .andExpect(status().isOk())
+                .andReturn();
+
+        // 3. 액세스 토큰 발급 및 확보
+        String responseContentOfSignIn = resultOfSignIn.getResponse().getContentAsString();
+        JsonNode responseJsonOfSignIn = objectMapper.readTree(responseContentOfSignIn);
+        String accessToken = responseJsonOfSignIn.get("accessToken").asText();
+
+        // when
+        // 사용자의 리프레시 토큰을 활용하여 액세스 토큰 갱신
+        String renewedAccessToken = jwtTokenProvider.issueToken(client, "refresh");
+
+        // then
+        // 최초 발급된 액세스 토큰, 갱신되 액세스 토큰의 헤더, 페이로드, 서명을 비교하여
+        // 헤더는 완전히 동일, 페이로드는 일부가 동일, 서명은 서로 다를 경우 ; 테스트 성공
+        // (아래 코드는 조금 더 테스트다운 방법으로 성공할 수 있도록 수정이 필요함)
+        System.out.println(accessToken);
+        System.out.println(renewedAccessToken);
+
+        String[] original = accessToken.split("\\.");
+        String[] renewed = renewedAccessToken.split("\\.");
+
+        int orgLen = original[1].length();
+        int rnwLen = renewed[1].length();
+
+        if (original[0].equals(renewed[0]) && !original[2].equals(renewed[2]) &&
+                original[1].substring(0,20).equals(renewed[1].substring(0,20)) &&
+                original[1].substring(orgLen-20, orgLen).equals(renewed[1].substring(rnwLen-20, rnwLen))
+        ) {
+            System.out.println("액세스 토큰 갱신 성공!");
+        } else {
+            System.out.println("액세스 토큰 갱신 실패!");
+        }
+    }
+}


### PR DESCRIPTION

- 리프레시 토큰을 통한 액세스 토큰 갱신 구현
- JWT 발급 순서 : 로그인 시, 액세스 토큰 발급 -> 액세스 토큰 기한 만료 시, 액세스 토큰 값을 기반으로 리프레시 토큰 생성 -> 리프레시 토큰으로 액세스 토큰 갱신
   (로그인 엔드포인트와는 다른 엔드포인트(/api/token)에서 리프레시 토큰 생성 및 액세스 토큰 갱신이 진행됨)
- 테스트 코드 ; 최초 발급된 액세스 토큰과 갱신된 액세스 토큰의 헤더, 페이로드, 서명을 각각 비교하는 로직으로 작성 (추후 리팩토링 필요)
    - 헤더는 동일 / iat, exp의 차이 때문에 페이로드는 거의 유사하지만 조금 다름 / 서명은 다르다는 조건이 충족하면 테스트 성공