### PR TITLE
Feat #13 : Discord Webhook 식당 추천 API 구현

### DIFF
--- a/src/main/java/com/example/skeleton/domain/client/repository/ClientRepository.java
+++ b/src/main/java/com/example/skeleton/domain/client/repository/ClientRepository.java
@@ -1,13 +1,17 @@
 package com.example.skeleton.domain.client.repository;
 
+import java.util.ArrayList;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.example.skeleton.domain.client.entity.Client;
+import com.example.skeleton.domain.client.entity.Permission;
 
 public interface ClientRepository extends JpaRepository<Client, Long> {
     public boolean existsByClientId(String clientId);
 
     public Optional<Client> findByClientId(String clientId);
+
+    public ArrayList<Client> findByPermission(Permission permission);
 }

--- a/src/main/java/com/example/skeleton/domain/gourmet/repository/GourmetRepository.java
+++ b/src/main/java/com/example/skeleton/domain/gourmet/repository/GourmetRepository.java
@@ -1,13 +1,31 @@
 package com.example.skeleton.domain.gourmet.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.example.skeleton.domain.gourmet.entity.Gourmet;
 
 public interface GourmetRepository extends JpaRepository<Gourmet, Long> {
-    boolean existsByGourmetCode(String gourmetCode);
+        boolean existsByGourmetCode(String gourmetCode);
 
-    Optional<Gourmet> findByGourmetCode(String gourmetCode);
+        Optional<Gourmet> findByGourmetCode(String gourmetCode);
+
+        @Query("SELECT r FROM Restaurant r " +
+                        "WHERE r.category = :category " +
+                        "AND (6371 * " +
+                        "    acos(cos(radians(:clientLatitude)) * " +
+                        "    cos(radians(r.latitude)) * " +
+                        "    cos(radians(:clientLongitude) - radians(r.longitude)) + " +
+                        "    sin(radians(:clientLatitude)) * " +
+                        "    sin(radians(r.latitude))) <= 0.5) " +
+                        "ORDER BY r.rating DESC " +
+                        "LIMIT 5")
+        List<Gourmet> findTop5GourmetsByCategoryAndPoint(@Param("category") String category,
+                        @Param("clientLatitude") double clientLatitude,
+                        @Param("clientLongitude") double clientLongitude);
 }

--- a/src/main/java/com/example/skeleton/global/webhook/config/DiscordWebhookConfig.java
+++ b/src/main/java/com/example/skeleton/global/webhook/config/DiscordWebhookConfig.java
@@ -1,0 +1,21 @@
+package com.example.skeleton.global.webhook.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class DiscordWebhookConfig {
+    @Bean
+    public WebClient discordWebhookWebClient() {
+        /*
+         * 현재는 각 클라이언트의 discord url 정보가 없기 때문에 한 곳에 일괄적으로 보내진다.
+         * 따라서 실제 서비스에 들어가려면 수정이 필요하다.
+         */
+        return WebClient.builder()
+                .baseUrl(
+                        "https://discord.com/api/webhooks/1171480929039028366/oNdHFvHouOfvbfTqTeLuHXYV-oJzO6_UThi3Cc5F5Jrs0sRNYs0M8lI0yvdAncEUqxJv")
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/skeleton/global/webhook/dto/DiscordWebhookMessage.java
+++ b/src/main/java/com/example/skeleton/global/webhook/dto/DiscordWebhookMessage.java
@@ -1,0 +1,67 @@
+package com.example.skeleton.global.webhook.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class DiscordWebhookMessage {
+    private String username;
+    private String avatar_url;
+    private String content;
+    private List<Embed> embeds;
+}
+
+/*
+ * Json data 예시
+ * {
+  "username": "Webhook",
+  "avatar_url": "https://i.imgur.com/4M34hi2.png",
+  "content": "Text message. Up to 2000 characters.",
+  "embeds": [
+    {
+      "author": {
+        "name": "Birdie♫",
+        "url": "https://www.reddit.com/r/cats/",
+        "icon_url": "https://i.imgur.com/R66g1Pe.jpg"
+      },
+      "title": "Title",
+      "url": "https://google.com/",
+      "description": "Text message. You can use Markdown here. *Italic* **bold** __underline__ ~~strikeout~~ [hyperlink](https://google.com) `code`",
+      "color": 15258703,
+      "fields": [
+        {
+          "name": "Text",
+          "value": "More text",
+          "inline": true
+        },
+        {
+          "name": "Even more text",
+          "value": "Yup",
+          "inline": true
+        },
+        {
+          "name": "Use `\"inline\": true` parameter, if you want to display fields in the same line.",
+          "value": "okay..."
+        },
+        {
+          "name": "Thanks!",
+          "value": "You're welcome :wink:"
+        }
+      ],
+      "thumbnail": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/3/38/4-Nature-Wallpapers-2014-1_ukaavUI.jpg"
+      },
+      "image": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/5/5a/A_picture_from_China_every_day_108.jpg"
+      },
+      "footer": {
+        "text": "Woah! So cool! :smirk:",
+        "icon_url": "https://i.imgur.com/fKL31aD.jpg"
+      }
+    }
+  ]
+}
+ */

--- a/src/main/java/com/example/skeleton/global/webhook/dto/Embed.java
+++ b/src/main/java/com/example/skeleton/global/webhook/dto/Embed.java
@@ -1,0 +1,95 @@
+package com.example.skeleton.global.webhook.dto;
+
+import java.util.List;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/*
+ * 이번 프로젝트에서는 fields만 사용한다.
+ */
+@Getter
+@Builder
+public class Embed {
+    private Author author;
+    private String title;
+    private String url;
+    private String description;
+    private int color;
+    private List<Field> fields;
+    private Thumbnail thumbnail;
+    private Image image;
+    private Footer footer;
+
+    public static class Author {
+        private String name;
+        private String url;
+        private String icon_url;
+    }
+
+    @Getter
+    @Builder
+    public static class Field {
+        private String name;
+        private String value;
+        private boolean inline;
+    }
+
+    public static class Thumbnail {
+        private String url;
+    }
+
+    public static class Image {
+        private String url;
+    }
+
+    public static class Footer {
+        private String text;
+        private String icon_url;
+    }
+}
+
+/*
+ * Embed 예시
+ * {
+      "author": {
+        "name": "Birdie♫",
+        "url": "https://www.reddit.com/r/cats/",
+        "icon_url": "https://i.imgur.com/R66g1Pe.jpg"
+      },
+      "title": "Title",
+      "url": "https://google.com/",
+      "description": "Text message. You can use Markdown here. *Italic* **bold** __underline__ ~~strikeout~~ [hyperlink](https://google.com) `code`",
+      "color": 15258703,
+      "fields": [
+        {
+          "name": "Text",
+          "value": "More text",
+          "inline": true
+        },
+        {
+          "name": "Even more text",
+          "value": "Yup",
+          "inline": true
+        },
+        {
+          "name": "Use `\"inline\": true` parameter, if you want to display fields in the same line.",
+          "value": "okay..."
+        },
+        {
+          "name": "Thanks!",
+          "value": "You're welcome :wink:"
+        }
+      ],
+      "thumbnail": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/3/38/4-Nature-Wallpapers-2014-1_ukaavUI.jpg"
+      },
+      "image": {
+        "url": "https://upload.wikimedia.org/wikipedia/commons/5/5a/A_picture_from_China_every_day_108.jpg"
+      },
+      "footer": {
+        "text": "Woah! So cool! :smirk:",
+        "icon_url": "https://i.imgur.com/fKL31aD.jpg"
+      }
+    }
+ */

--- a/src/main/java/com/example/skeleton/global/webhook/scheduler/DiscordWebhookScheduler.java
+++ b/src/main/java/com/example/skeleton/global/webhook/scheduler/DiscordWebhookScheduler.java
@@ -1,0 +1,28 @@
+package com.example.skeleton.global.webhook.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.example.skeleton.global.webhook.service.DiscordWebhookService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class DiscordWebhookScheduler {
+
+    private final DiscordWebhookService discordWebhookService;
+
+    @Scheduled(cron = "0 30 11 * * ?")
+    public void executeDiscordWebhook() {
+
+        try {
+            discordWebhookService.executeDiscordWebhook();
+            log.info("전송 성공");
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/example/skeleton/global/webhook/service/DiscordWebhookService.java
+++ b/src/main/java/com/example/skeleton/global/webhook/service/DiscordWebhookService.java
@@ -1,0 +1,114 @@
+package com.example.skeleton.global.webhook.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.example.skeleton.domain.client.entity.Client;
+import com.example.skeleton.domain.client.entity.Permission;
+import com.example.skeleton.domain.client.repository.ClientRepository;
+import com.example.skeleton.domain.gourmet.entity.Gourmet;
+import com.example.skeleton.domain.gourmet.repository.GourmetRepository;
+import com.example.skeleton.global.model.Point;
+import com.example.skeleton.global.webhook.dto.DiscordWebhookMessage;
+import com.example.skeleton.global.webhook.dto.Embed;
+import com.example.skeleton.global.webhook.dto.Embed.Field;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class DiscordWebhookService {
+    private final WebClient client;
+    private final DiscordWebhookService webhookService;
+    private final ClientRepository clientRepo;
+    private final GourmetRepository gourmetRepo;
+
+    /*
+     * webhook service 전체 로직
+     * 
+     * 1. 추천 허용한 클라이언트 리스트 조회
+     * 2. 각 클라이언트 위치에 따라 500미터 이내의 식당 평점 높은 순으로 카테고리별 5개씩 조회
+     * 3. request body 구성(Embed > Field)
+     * 4. webhook로 request 전송(response 없음)
+     * 
+     */
+
+    public void executeDiscordWebhook() {
+        // 1. 추천 허용한 클라이언트 리스트 조회
+        List<Client> clientList = clientRepo.findByPermission(Permission.ALLOWED);
+
+        for (Client client : clientList) {
+
+            Point clientPoint = client.getPoint();
+            Double clientLatitude = Double.parseDouble(clientPoint.getLatitude());
+            Double clientLongitude = Double.parseDouble(clientPoint.getLongitude());
+
+            // 2. 각 클라이언트 위치에 따라 500미터 이내의 식당 평점 높은 순으로 카테고리별 5개씩 조회
+            List<Gourmet> chinaGourmetList = gourmetRepo.findTop5GourmetsByCategoryAndPoint("중식",
+                    clientLatitude, clientLongitude);
+            List<Gourmet> japanGourmetList = gourmetRepo.findTop5GourmetsByCategoryAndPoint("일식",
+                    clientLatitude, clientLongitude);
+            List<Gourmet> fastfoodGourmetList = gourmetRepo.findTop5GourmetsByCategoryAndPoint("패스트 푸드",
+                    clientLatitude, clientLongitude);
+
+            // 3. request body 구성(Embed > Field)
+            DiscordWebhookMessage message = configWebhookMessage(client.getClientId(), chinaGourmetList,
+                    japanGourmetList, fastfoodGourmetList);
+
+            // 4. webhook로 request 전송(response 없음)
+            webhookService.sendDiscordMessage(message);
+
+        }
+    }
+
+    private DiscordWebhookMessage configWebhookMessage(String clientId, List<Gourmet> chinaGourmetList,
+            List<Gourmet> japanGourmetList, List<Gourmet> fastfoodGourmetList) {
+
+        List<Field> fieldList = new ArrayList<>();
+        StringBuilder chinaFieldValue = configFieldValue(chinaGourmetList);
+        StringBuilder japanFieldValue = configFieldValue(japanGourmetList);
+        StringBuilder fastfoodFieldValue = configFieldValue(fastfoodGourmetList);
+
+        fieldList.add(Field.builder().name("중식").value(chinaFieldValue.toString()).build());
+        fieldList.add(Field.builder().name("일식").value(japanFieldValue.toString()).build());
+        fieldList.add(Field.builder().name("패스트 푸드").value(fastfoodFieldValue.toString()).build());
+
+        List<Embed> embedList = new ArrayList<>();
+        embedList.add(Embed.builder().fields(fieldList).build());
+
+        DiscordWebhookMessage message = DiscordWebhookMessage.builder()
+                .username("맛집 알림")
+                .content(clientId + "님의 위치 반경 500m 이내 맛집 목록입니다.")
+                .embeds(embedList)
+                .build();
+
+        return message;
+
+    }
+
+    private StringBuilder configFieldValue(List<Gourmet> gourmetList) {
+
+        StringBuilder fieldValue = new StringBuilder("");
+        for (int i = 0; i < gourmetList.size(); i++) {
+            fieldValue.append(String.format("%s. %s\n", i, gourmetList.get(i)));
+        }
+        return fieldValue;
+
+    }
+
+    private void sendDiscordMessage(DiscordWebhookMessage message) {
+
+        client.post()
+                .uri("")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(message)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+
+    }
+}


### PR DESCRIPTION
- 서버 구동이 안 돼서 테스트는 진행하지 못했습니다.
- 프로젝트 새로 하나 파서 같은 코드로 테스트해봤는데 webhook 자체는 잘 작동합니다.
![image](https://github.com/Team-Enigma23/location-based-gourmet-recommendation-project/assets/98063854/1fee2b94-b51e-4d37-ade8-3ce172b1e08e)


### 전체 로직
1. 추천 허용한 클라이언트 리스트 조회
2. 각 클라이언트 위치에 따라 500미터 이내의 식당 평점 높은 순으로 카테고리별 5개씩 조회
3. request body 구성(Embed > Field)
4. webhook로 request 전송(response 없음)

### 보완할 점
![image](https://github.com/Team-Enigma23/location-based-gourmet-recommendation-project/assets/98063854/678905c8-b712-4b5f-ac75-4d2468c9f311)

2번 부분에서 gourmet 테이블을 카테고리만 다르게 해서 3번 반복 조회하고 있습니다.
이 부분을 db 접속 한 번으로 처리하는 방법이 있을까요? 
의견 주시면 감사하겠습니다.