### PR TITLE
Test #15 : 리프레시 토큰 테스트 개선

### DIFF
--- a/src/main/java/com/example/skeleton/global/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/skeleton/global/config/jwt/JwtTokenProvider.java
@@ -25,7 +25,7 @@ import java.util.*;
 @Component
 public class JwtTokenProvider implements InitializingBean {
 
-    // 사용자 권한 정보
+    // 사용자 권한 정보 (현재 사용자 권한은 세분화되어 있지 않음.)
     public static final String AUTH = "auth";
 
     // JWT 서명용 비밀키
@@ -83,7 +83,7 @@ public class JwtTokenProvider implements InitializingBean {
                 .setSubject(client.getClientId())
                 .setExpiration(expiry)
                 .setIssuedAt(new Date())
-                // Claim 지정(clientId 저장)
+                // Claim 지정(clientId 저장/ 사용자 권한을 다양화할 경우, 사용자 권한을 claim에 포함시켜야 함.)
                 .addClaims(Map.of("clientId", client.getClientId()))
                 .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
@@ -121,6 +121,7 @@ public class JwtTokenProvider implements InitializingBean {
         Claims claims = getClaims(token);
 
         if (claims != null) {
+            // 사용자 권한이 세분화되면 반환 유형을 String[].class로 수정 필요
             String authValue = claims.get(AUTH, String.class);
 
             if (authValue != null && !authValue.isEmpty()) {

--- a/src/main/resources/enigma23.txt
+++ b/src/main/resources/enigma23.txt
@@ -1,0 +1,6 @@
+100000
+Team-Enigma23Team-Enigma23Team-Enigma23
+
+문자를 암호화 값으로 변환하기 위한 코드
+String[] source = {};
+for(String str : source) log.info("plane :: {}, encrypt :: {}", str, encryptor.encrypt(str));

--- a/src/main/resources/enigma23.txt
+++ b/src/main/resources/enigma23.txt
@@ -1,6 +1,0 @@
-100000
-Team-Enigma23Team-Enigma23Team-Enigma23
-
-문자를 암호화 값으로 변환하기 위한 코드
-String[] source = {};
-for(String str : source) log.info("plane :: {}, encrypt :: {}", str, encryptor.encrypt(str));


### PR DESCRIPTION

- 리프레시 토큰 테스트 개선(then 부분 수정)
- 현재 액세스 토큰 claim에는 권한정보가 포함되어 있지 않음(그럴 필요가 없음). -> 추후 권한정보 포함될 경우, TokenProvider 코드 수정해야 한다는 주석 추가